### PR TITLE
Fix: Prevent NPE by providing default score thresholds

### DIFF
--- a/src/main/java/com/example/promptngapi/config/ScoreThresholdsConfig.java
+++ b/src/main/java/com/example/promptngapi/config/ScoreThresholdsConfig.java
@@ -13,10 +13,10 @@ import jakarta.validation.constraints.NotNull;
 public class ScoreThresholdsConfig {
 
     @NotNull
-    private Double similarityThreshold; // Jaro-Winkler類似度チェックの閾値
+    private Double similarityThreshold = 0.7; // Jaro-Winkler類似度チェックの閾値 (デフォルト値)
 
     @NotNull
-    private Integer nonJapaneseSentenceWordThreshold; // 非日本語の文章と判定するための単語数の閾値
+    private Integer nonJapaneseSentenceWordThreshold = 3; // 非日本語の文章と判定するための単語数の閾値 (デフォルト値)
 
     public Double getSimilarityThreshold() {
         return similarityThreshold;


### PR DESCRIPTION
Resolves a NullPointerException that occurred when accessing score thresholds if they were not properly loaded from the YAML configuration at runtime.

The `similarityThreshold` and `nonJapaneseSentenceWordThreshold` fields in `ScoreThresholdsConfig.java` (which are Double and Integer types) were being accessed as primitive types in `PromptInjectionDetector.java`. If these fields were null (e.g., if YAML loading failed silently or if the bean was not fully initialized before use), a NullPointerException would occur.

This commit fixes the issue by initializing these fields directly in `ScoreThresholdsConfig.java` with sensible default values (0.7 for similarity and 3 for non-Japanese word count). The `@NotNull` annotations are retained for validation if values are provided in the YAML.

Unit tests for `PromptInjectionDetector` continue to pass, as they utilize a mocked `ScoreThresholdsConfig`.