### PR TITLE
Fix: Ensure score_thresholds.yaml is loaded and validated

### DIFF
--- a/src/main/java/com/example/promptngapi/config/ScoreThresholdsConfig.java
+++ b/src/main/java/com/example/promptngapi/config/ScoreThresholdsConfig.java
@@ -13,10 +13,10 @@ import jakarta.validation.constraints.NotNull;
 public class ScoreThresholdsConfig {
 
     @NotNull
-    private Double similarityThreshold = 0.7; // Jaro-Winkler類似度チェックの閾値 (デフォルト値)
+    private Double similarityThreshold; // Jaro-Winkler類似度チェックの閾値
 
     @NotNull
-    private Integer nonJapaneseSentenceWordThreshold = 3; // 非日本語の文章と判定するための単語数の閾値 (デフォルト値)
+    private Integer nonJapaneseSentenceWordThreshold; // 非日本語の文章と判定するための単語数の閾値
 
     public Double getSimilarityThreshold() {
         return similarityThreshold;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  config:
+    import: optional:classpath:score_thresholds.yaml


### PR DESCRIPTION
This commit addresses an issue where values from `score_thresholds.yaml` were not being properly loaded, and a previous fix for a NullPointerException (by adding default initializers) inadvertently masked this problem.

Changes:
1.  Added `src/main/resources/application.yaml` with `spring.config.import: optional:classpath:score_thresholds.yaml` to ensure Spring Boot explicitly loads the custom configuration file.
2.  Removed default value initializers from `similarityThreshold` and `nonJapaneseSentenceWordThreshold` in `ScoreThresholdsConfig.java`. The application now relies solely on the values provided in `score_thresholds.yaml`.
3.  The `@NotNull` validation annotations on these fields in `ScoreThresholdsConfig.java` will now correctly cause the application to fail on startup if the properties are not found in `score_thresholds.yaml`, ensuring configuration errors are caught early.

This ensures that the externalized threshold configuration is correctly loaded and that missing configurations lead to application startup failure, rather than silent operation with potentially incorrect default values. Unit tests continue to pass with mocked configurations.